### PR TITLE
RGB8 format, 388x filesize reduction.

### DIFF
--- a/Plugins/RenderTargetSerializerPlugin/Source/RenderTargetSerializer/Private/RenderTargetSerializerBPLibrary.cpp
+++ b/Plugins/RenderTargetSerializerPlugin/Source/RenderTargetSerializer/Private/RenderTargetSerializerBPLibrary.cpp
@@ -11,6 +11,9 @@
 #include "Math/Vector.h"
 #include "Engine/TextureRenderTarget2D.h"
 #include "Engine/Texture2D.h"
+#include "UnrealClient.h"
+#include "RHITypes.h"
+#include "TextureResource.h"
 
 URenderTargetSerializerBPLibrary::URenderTargetSerializerBPLibrary(const FObjectInitializer& ObjectInitializer)
 : Super(ObjectInitializer)
@@ -73,7 +76,7 @@ UTexture2D* URenderTargetSerializerBPLibrary::DeserializeRenderTarget(const TArr
     }
 
     // Lock the texture for writing
-    FTexture2DMipMap& Mip = Texture2D->PlatformData->Mips[0];
+    FTexture2DMipMap& Mip = Texture2D->GetPlatformData()->Mips[0];
     void* Data = Mip.BulkData.Lock(LOCK_READ_WRITE);
 
     // Copy pixel data into the texture after converting to FColor

--- a/Plugins/RenderTargetSerializerPlugin/Source/RenderTargetSerializer/Private/RenderTargetSerializerBPLibrary.cpp
+++ b/Plugins/RenderTargetSerializerPlugin/Source/RenderTargetSerializer/Private/RenderTargetSerializerBPLibrary.cpp
@@ -1,6 +1,5 @@
 /*
 	This code was written by Alexander Chadfield
-	(and modified by the devious bovid known as Aspen)
 	
 	Plugin created by Alexander Chadfield
 */

--- a/Plugins/RenderTargetSerializerPlugin/Source/RenderTargetSerializer/Private/RenderTargetSerializerBPLibrary.cpp
+++ b/Plugins/RenderTargetSerializerPlugin/Source/RenderTargetSerializer/Private/RenderTargetSerializerBPLibrary.cpp
@@ -64,7 +64,7 @@ TArray<uint8> URenderTargetSerializerBPLibrary::SerializeRenderTarget(UTextureRe
             };
 
             // Add three channels into the vector
-            Channels.Append(Rgb, ARRAY_COUNT(Rgb));
+            Channels.Append(Rgb, sizeof(Rgb) / sizeof(Rgb[0]));
         }
     }
 

--- a/Plugins/RenderTargetSerializerPlugin/Source/RenderTargetSerializer/Private/RenderTargetSerializerBPLibrary.cpp
+++ b/Plugins/RenderTargetSerializerPlugin/Source/RenderTargetSerializer/Private/RenderTargetSerializerBPLibrary.cpp
@@ -57,11 +57,11 @@ TArray<uint8> URenderTargetSerializerBPLibrary::SerializeRenderTarget(UTextureRe
             // Convert rgba32f pixel colour to rgb8ui format
             FColor PixelColor = PixelData[y * Width + x];
 
-            uint8 Rgb[3] = [
+            uint8 Rgb[3] = {
                 PixelColor.R,
                 PixelColor.G,
-                PixelColor.B,
-            ];
+                PixelColor.B
+            };
 
             // Add three channels into the vector
             Channels.Append(Rgb, ARRAY_COUNT(Rgb));
@@ -95,11 +95,11 @@ UTexture2D* URenderTargetSerializerBPLibrary::DeserializeRenderTarget(const TArr
     for (int32 PixelNum = 0; PixelNum < (Width * Height); ++PixelNum)
     {
         // Interestingly we don't need to swap R and B despite the BGRA format.
-        uint8 Rgb[3] = [
+        uint8 Rgb[3] = {
             Channels[PixelNum * 3 + 0],
             Channels[PixelNum * 3 + 1],
-            Channels[PixelNum * 3 + 2],
-        ];
+            Channels[PixelNum * 3 + 2]
+        };
         FColor PixelColor(Rgb[0], Rgb[1], Rgb[2], 255);
         ColorData[PixelNum] = PixelColor;
     }

--- a/Plugins/RenderTargetSerializerPlugin/Source/RenderTargetSerializer/Public/RenderTargetSerializerBPLibrary.h
+++ b/Plugins/RenderTargetSerializerPlugin/Source/RenderTargetSerializer/Public/RenderTargetSerializerBPLibrary.h
@@ -1,5 +1,6 @@
 /*
 	This code was written by Alexander Chadfield
+	(and modified by the devious bovid known as Aspen)
 	
 	Plugin created by Alexander Chadfield
 */
@@ -19,8 +20,8 @@ class URenderTargetSerializerBPLibrary : public UBlueprintFunctionLibrary
 public:
 
 	UFUNCTION(BlueprintCallable, meta = (DisplayName = "Serialize Render Target", Keywords = "RenderTargetSerializer"), Category = "Render Target Serialization")
-	static TArray<FVector> SerializeRenderTarget(UTextureRenderTarget2D* RenderTarget);
+	static TArray<uint8> SerializeRenderTarget(UTextureRenderTarget2D* RenderTarget);
 
 	UFUNCTION(BlueprintCallable, meta = (DisplayName = "Deserialize Render Target", Keywords = "RenderTargetSerializer"), Category = "Render Target Serialization")
-	static UTexture2D* DeserializeRenderTarget(const TArray<FVector>& PixelVectors, int32 Width, int32 Height);
+	static UTexture2D* DeserializeRenderTarget(const TArray<uint8>& PixelVectors, int32 Width, int32 Height);
 };

--- a/Plugins/RenderTargetSerializerPlugin/Source/RenderTargetSerializer/Public/RenderTargetSerializerBPLibrary.h
+++ b/Plugins/RenderTargetSerializerPlugin/Source/RenderTargetSerializer/Public/RenderTargetSerializerBPLibrary.h
@@ -1,6 +1,5 @@
 /*
 	This code was written by Alexander Chadfield
-	(and modified by the devious bovid known as Aspen)
 	
 	Plugin created by Alexander Chadfield
 */


### PR DESCRIPTION
Heya! I modified your plugin for my partner's game, to fix compilation errors under UE5 and to optimize the filesize when the produced `TArray`  is placed into a save file.

Inexplicably, the `TArray<TVector>` approach uses more than 1KiB of savefile space ***per pixel!*** Full images are thus many megabytes even for trivially small rendertargets, and it becomes infeasible to save larger ones. I am really not sure why this is.

This change replaces `TVector` with three `uint8`s for R,G,B (ignoring A) - reducing the filesize by a factor of 388 and bringing the savefile to a size comparable with a `.bmp` file.

This is of course for a very different usecase than yours. I am putting this PR here primarily as a resource for others in case it is useful or adaptable to your needs.